### PR TITLE
GitHub Projects用ブックマークレットを追加 - Issueタイトル抽出機能付き

### DIFF
--- a/link_for_github_projects.js
+++ b/link_for_github_projects.js
@@ -1,0 +1,15 @@
+﻿export default () => {
+    const title = document.title;
+    const url = document.URL;
+
+    const issue_no = url.match(/\/issues\/(\d+)$/);
+    console.log(issue_no);
+    if (issue_no) {
+        // ページタイトルから「 · Issue #{issue_no}」の左側のテキストを抽出
+        const page_title = title.split(' · Issue #')[0];
+        navigator.clipboard.writeText(`[#${issue_no[1]}](${url}) ${page_title}`).then();
+        return;
+    }
+
+    // navigator.clipboard.writeText(`[${title}](${url})`).then();
+};


### PR DESCRIPTION
# GitHub Issue用ブックマークレット追加

## 概要
GitHub Issuesページでブックマークレットを実行すると、Issue番号とタイトルを含むリンク形式でクリップボードにコピーする機能を追加しました。

## 変更内容

### 新規ファイル追加
- `link_for_github_projects.js` - GitHub Projects用ブックマークレット

### 機能仕様
- **対象URL**: `github.com/{account_name}/{repository_name}/issues/{issue_no}` パターン
- **ページタイトル抽出**: 「 · Issue #{issue_no}」の左側のテキストのみ取得
- **出力形式**: `[#issue_no](url) page_title`

### 動作例
- **入力URL**: `https://github.com/Japanprint/Apps_using_chatgpt/issues/107`
- **ページタイトル**: `レシピ用のテーブル作成 · Issue #107 · Japanprint/Apps_using_chatgpt`
- **出力**: `[#107](https://github.com/Japanprint/Apps_using_chatgpt/issues/107) レシピ用のテーブル作成`

## 使用方法
```javascript
javascript:import("https://booleanoid.github.io/bookmarklet/link_for_github_projects.js").then(m=>m.default());
```

## 技術的実装
- `title.split(' · Issue #')[0]` でページタイトルからIssue番号の左側を抽出
- `navigator.clipboard.writeText()` でクリップボードに保存
- 既存のブックマークレットと同じ `export default()` 形式で実装

## ブランチ
- `github-projects-bookmarklet`